### PR TITLE
Test SLF4J 1.7.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,9 +19,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.mortbay.jetty</groupId>
+    <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-parent</artifactId>
-    <version>13</version>
+    <version>21</version>
   </parent>
 
   <groupId>org.mortbay.jetty.testwars</groupId>
@@ -35,7 +35,7 @@
     <jsp-2-1-version>2.1.v20100127</jsp-2-1-version>
     <junit-version>3.8.2</junit-version>
     <junit4-version>4.8.1</junit4-version>
-    <jetty-test-helper-version>1.6</jetty-test-helper-version>
+    <jetty-test-helper-version>2.7</jetty-test-helper-version>
   </properties>
   <scm>
     <connection>scm:git:git@github.com:jetty-project/jetty-test-wars.git</connection>
@@ -78,6 +78,7 @@
     <module>test-war-slf4j_1.6.1</module>
     <module>test-war-slf4j_1.6.6</module>
     <module>test-war-slf4j_1.7.2</module>
+    <module>test-war-slf4j_1.7.5</module>
     <!-- Used by jetty-webapp-verifier -->
     <module>test-war-jruby</module>
     <module>test-war-jython</module>

--- a/test-war-slf4j_1.7.5/pom.xml
+++ b/test-war-slf4j_1.7.5/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+// ========================================================================
+// Copyright (c) Webtide LLC
+// 
+// All rights reserved. This program and the accompanying materials
+// are made available under the terms of the Eclipse Public License v1.0
+// and Apache License v2.0 which accompanies this distribution.
+//
+// The Eclipse Public License is available at 
+// http://www.eclipse.org/legal/epl-v10.html
+//
+// The Apache License v2.0 is available at
+// http://www.apache.org/licenses/LICENSE-2.0.txt
+//
+// You may elect to redistribute this code under either of these licenses. 
+// ========================================================================
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.mortbay.jetty.testwars</groupId>
+    <artifactId>testwars-parent</artifactId>
+    <version>9.0.1-SNAPSHOT</version>
+  </parent>
+  <artifactId>test-war-slf4j_1.7.5</artifactId>
+  <name>Jetty :: Logging Test War :: Slf4J 1.7.5</name>
+  <packaging>war</packaging>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <configuration>
+              <descriptorRefs>
+                <descriptorRef>config</descriptorRef>
+              </descriptorRefs>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+  <dependencies>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.5</version>
+    </dependency>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>servlet-api</artifactId>
+      <version>2.5</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/test-war-slf4j_1.7.5/src/main/assembly/config.xml
+++ b/test-war-slf4j_1.7.5/src/main/assembly/config.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assembly>
+  <id>config</id>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <formats>
+    <format>jar</format>
+  </formats>
+  <fileSets>
+
+    <fileSet>
+      <directory>src/main/config</directory>
+      <outputDirectory></outputDirectory>
+      <includes>
+        <include>**</include>
+      </includes>
+    </fileSet>
+  </fileSets>
+
+</assembly>
+

--- a/test-war-slf4j_1.7.5/src/main/config/test-contexts/test-war-slf4j_1.7.2.xml
+++ b/test-war-slf4j_1.7.5/src/main/config/test-contexts/test-war-slf4j_1.7.2.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"  encoding="ISO-8859-1"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure.dtd">
+
+<Configure class="org.eclipse.jetty.webapp.WebAppContext">
+  <Set name="contextPath">/test-slf4j-1_7_2</Set>
+  <Set name="war"><SystemProperty name="jetty.home" default="."/>/test-apps/test-war-slf4j_1.7.2.war</Set>
+  <Set name="extractWAR">false</Set>
+  <Set name="copyWebDir">false</Set>
+</Configure>

--- a/test-war-slf4j_1.7.5/src/main/config/test-contexts/test-war-slf4j_1.7.5.xml
+++ b/test-war-slf4j_1.7.5/src/main/config/test-contexts/test-war-slf4j_1.7.5.xml
@@ -2,8 +2,8 @@
 <!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
-  <Set name="contextPath">/test-slf4j-1_7_2</Set>
-  <Set name="war"><SystemProperty name="jetty.home" default="."/>/test-apps/test-war-slf4j_1.7.2.war</Set>
+  <Set name="contextPath">/test-slf4j-1_7_5</Set>
+  <Set name="war"><SystemProperty name="jetty.home" default="."/>/test-apps/test-war-slf4j_1.7.5.war</Set>
   <Set name="extractWAR">false</Set>
   <Set name="copyWebDir">false</Set>
 </Configure>

--- a/test-war-slf4j_1.7.5/src/main/java/org/mortbay/jetty/tests/webapp/AppException.java
+++ b/test-war-slf4j_1.7.5/src/main/java/org/mortbay/jetty/tests/webapp/AppException.java
@@ -1,0 +1,34 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2013 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.mortbay.jetty.tests.webapp;
+
+/**
+ * WebApp specific Exception.
+ * <p>
+ * Here to make sure that the centralized logging doesn't have
+ * a classpath / classloader choke on this kind of log.
+ */
+@SuppressWarnings("serial")
+public class AppException extends RuntimeException
+{
+    public AppException(String msg)
+    {
+        super(msg);
+    }
+}

--- a/test-war-slf4j_1.7.5/src/main/java/org/mortbay/jetty/tests/webapp/LoggingServlet.java
+++ b/test-war-slf4j_1.7.5/src/main/java/org/mortbay/jetty/tests/webapp/LoggingServlet.java
@@ -1,0 +1,64 @@
+// ========================================================================
+// Copyright (c) Webtide LLC
+// ------------------------------------------------------------------------
+// All rights reserved. This program and the accompanying materials
+// are made available under the terms of the Eclipse Public License v1.0
+// and Apache License v2.0 which accompanies this distribution.
+//
+// The Eclipse Public License is available at 
+// http://www.eclipse.org/legal/epl-v10.html
+//
+// The Apache License v2.0 is available at
+// http://www.apache.org/licenses/LICENSE-2.0.txt
+//
+// You may elect to redistribute this code under either of these licenses. 
+// ========================================================================
+
+package org.mortbay.jetty.tests.webapp;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Servlet implementation class LoggingServlet
+ */
+public class LoggingServlet extends HttpServlet
+{
+    private static final long serialVersionUID = 1L;
+    private static final String LOGID = "LoggingServlet(slf4j-1.7.5)";
+    private Logger log = LoggerFactory.getLogger(LoggingServlet.class);
+
+    /**
+     * Default constructor.
+     */
+    public LoggingServlet()
+    {
+        log.debug(LOGID + " initialized");
+    }
+
+    /**
+     * @see HttpServlet#doGet(HttpServletRequest request, HttpServletResponse
+     *      response)
+     */
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
+    {
+        log.info(LOGID + " GET requested");
+
+        log.warn(LOGID + " Slightly warn, with a chance of log events");
+
+        log.error(LOGID + " Nothing is (intentionally) being output by this Servlet");
+
+        Throwable severe = new AppException("App Exception (slfj-1.7.5)");
+
+        log.error(LOGID + " Whoops (intentionally) causing a Throwable",severe);
+    }
+
+}

--- a/test-war-slf4j_1.7.5/src/main/webapp/WEB-INF/web.xml
+++ b/test-war-slf4j_1.7.5/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://java.sun.com/xml/ns/javaee" xmlns:web="http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd" id="WebApp_ID" version="2.5">
+  <display-name>logging-slf4j-webapp</display-name>
+  <welcome-file-list>
+    <welcome-file>index.html</welcome-file>
+    <welcome-file>index.htm</welcome-file>
+    <welcome-file>index.jsp</welcome-file>
+    <welcome-file>default.html</welcome-file>
+    <welcome-file>default.htm</welcome-file>
+    <welcome-file>default.jsp</welcome-file>
+  </welcome-file-list>
+  <servlet>
+    <description></description>
+    <display-name>LoggingServlet</display-name>
+    <servlet-name>LoggingServlet</servlet-name>
+    <servlet-class>org.mortbay.jetty.tests.webapp.LoggingServlet</servlet-class>
+  </servlet>
+  <servlet-mapping>
+    <servlet-name>LoggingServlet</servlet-name>
+    <url-pattern>/logging</url-pattern>
+  </servlet-mapping>
+</web-app>


### PR DESCRIPTION
- Adds support for testing SLF4J 1.7.5 (test-war-slf4j_1.7.5 module)
- Changes the jetty-parent dependency group from org.mortbay.jetty to org.eclipse.jetty and upgrades it from version 13 to version 21
